### PR TITLE
Add option to ColorScheme to blur transparent background

### DIFF
--- a/konsole/PKGBUILD
+++ b/konsole/PKGBUILD
@@ -1,3 +1,4 @@
+ 
 # Maintainer: pavbaranov <pavbaranov at gmail dot com>
 # Co-Maintainer: worldofpeace
 # for version with bugfix from cgit
@@ -8,7 +9,7 @@
 
 pkgname=konsole
 pkgver=17.12.3
-pkgrel=1.2
+pkgrel=1.3
 arch=(x86_64)
 url='https://kde.org/applications/system/konsole/'
 pkgdesc="KDE's terminal emulator"
@@ -38,7 +39,7 @@ cgit-14589ca.patch::"https://cgit.kde.org/konsole.git/patch/?id=14589ca"
 cgit-bed548e.patch::"https://cgit.kde.org/konsole.git/patch/?id=bed548e"
 cgit-2ffcca1.patch::"https://cgit.kde.org/konsole.git/patch/?id=2ffcca1"
 cgit-2a71f06.patch::"https://cgit.kde.org/konsole.git/patch/?id=2a71f06"
-)
+blur.patch)
 sha256sums=('fa0997c14a96252177e4808636ec43509eadb1482d54bb8a86b85810283f6cbc'
             'SKIP'
             'dfbc53016665dd9681addc5c110952c2430de5a92f2bf9bfd1c893f3b3720158'
@@ -60,7 +61,8 @@ sha256sums=('fa0997c14a96252177e4808636ec43509eadb1482d54bb8a86b85810283f6cbc'
             'b6cb7b6d072396d44de0f097a27ae1546602730505c869f1d922c54d8df5f66a'
             '3f9f5f0c0d3df09432b5ccf80496c07069f9d78fbaf262d69ed6cfdc9a158fe6'
             'af52aa81411395f7aec9621ff512d69d5cd9faad4ab9bf1f238f42fad8dd007d'
-            'aeac1cbe4e889e26fe649b90e919c6af5a7137a72621c6c3ebfb9a4f473f2b5a')
+            'aeac1cbe4e889e26fe649b90e919c6af5a7137a72621c6c3ebfb9a4f473f2b5a'
+            '405f42762acc06ef44e38754bcbfb61220c0605b27cd4c633b20c5684ee8946a')
 validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>
               F23275E4BF10AFC1DF6914A6DBD2CE893E2D1C87) # Christoph Feck <cfeck@kde.org>
 
@@ -129,6 +131,8 @@ prepare() {
 
   msg "scrollbars patch" # See: https://phabricator.kde.org/D11184
     patch -p1 -i ../cgit-2a71f06.patch
+  msg "blur patch" # See: https://phabricator.kde.org/D10015
+    patch -p1 -i ../blur.patch
 }
 
 build() {

--- a/konsole/blur.patch
+++ b/konsole/blur.patch
@@ -1,0 +1,315 @@
+ 
+From c63525fcdc52b3c3d6a82364bb21e8b41bd60c4d Mon Sep 17 00:00:00 2001
+From: Kurt Hindenburg <kurt.hindenburg@gmail.com>
+Date: Thu, 1 Feb 2018 08:52:05 -0500
+Subject: Add option to ColorScheme to blur transparent background
+
+Note that this does not affect KonsolePart; it is up to the app using
+it to enable transparency (see src/tests/demo_konsolepart).
+
+Patch by anemeth
+
+FEATURE: 198175
+Differential Revision: https://phabricator.kde.org/D10015
+---
+ src/ColorScheme.cpp       | 14 ++++++++++++++
+ src/ColorScheme.h         | 14 ++++++++++++++
+ src/ColorSchemeEditor.cpp | 12 ++++++++++++
+ src/ColorSchemeEditor.h   |  1 +
+ src/ColorSchemeEditor.ui  |  7 +++++++
+ src/MainWindow.cpp        | 16 ++++++++++++++++
+ src/MainWindow.h          |  1 +
+ src/SessionController.h   |  6 +++---
+ src/ViewManager.cpp       |  7 +++++++
+ src/ViewManager.h         |  7 +++++++
+ 10 files changed, 82 insertions(+), 3 deletions(-)
+
+diff --git a/src/ColorScheme.cpp b/src/ColorScheme.cpp
+index 15f0b1c..5cef6ce 100644
+--- a/src/ColorScheme.cpp
++++ b/src/ColorScheme.cpp
+@@ -164,6 +164,7 @@ ColorScheme::ColorScheme() :
+     _table(nullptr),
+     _randomTable(nullptr),
+     _opacity(1.0),
++    _blur(false),
+     _wallpaper(nullptr)
+ {
+     setWallpaper(QString());
+@@ -175,6 +176,7 @@ ColorScheme::ColorScheme(const ColorScheme &other) :
+     _table(nullptr),
+     _randomTable(nullptr),
+     _opacity(other._opacity),
++    _blur(other._blur),
+     _wallpaper(other._wallpaper)
+ {
+     setName(other.name());
+@@ -358,6 +360,16 @@ qreal ColorScheme::opacity() const
+     return _opacity;
+ }
+ 
++void ColorScheme::setBlur(bool blur)
++{
++    _blur = blur;
++}
++
++bool ColorScheme::blur() const
++{
++    return _blur;
++}
++
+ void ColorScheme::read(const KConfig &config)
+ {
+     KConfigGroup configGroup = config.group("General");
+@@ -366,6 +378,7 @@ void ColorScheme::read(const KConfig &config)
+ 
+     _description = i18n(schemeDescription.toUtf8().constData());
+     _opacity = configGroup.readEntry("Opacity", 1.0);
++    _blur = configGroup.readEntry("Blur", false);
+     setWallpaper(configGroup.readEntry("Wallpaper", QString()));
+ 
+     for (int i = 0; i < TABLE_COLORS; i++) {
+@@ -402,6 +415,7 @@ void ColorScheme::write(KConfig &config) const
+ 
+     configGroup.writeEntry("Description", _description);
+     configGroup.writeEntry("Opacity", _opacity);
++    configGroup.writeEntry("Blur", _blur);
+     configGroup.writeEntry("Wallpaper", _wallpaper->path());
+ 
+     for (int i = 0; i < TABLE_COLORS; i++) {
+diff --git a/src/ColorScheme.h b/src/ColorScheme.h
+index d76301a..43ad153 100644
+--- a/src/ColorScheme.h
++++ b/src/ColorScheme.h
+@@ -153,6 +153,17 @@ public:
+      */
+     qreal opacity() const;
+ 
++    /**
++     * Enables blur behind the transparent window
++     *
++     * Defaults to false.
++     */
++    void setBlur(bool blur);
++    /**
++     * Returns whether blur is enabled for this color scheme, see setBlur()
++     */
++    bool blur() const;
++
+     void setWallpaper(const QString &path);
+ 
+     ColorSchemeWallpaper::Ptr wallpaper() const;
+@@ -222,6 +233,9 @@ private:
+ 
+     qreal _opacity;
+ 
++    // enables blur behind the terminal window
++    bool _blur;
++
+     ColorSchemeWallpaper::Ptr _wallpaper;
+ 
+     static const quint16 MAX_HUE = 340;
+diff --git a/src/ColorSchemeEditor.cpp b/src/ColorSchemeEditor.cpp
+index 7967187..8ca3a51 100644
+--- a/src/ColorSchemeEditor.cpp
++++ b/src/ColorSchemeEditor.cpp
+@@ -93,6 +93,10 @@ ColorSchemeEditor::ColorSchemeEditor(QWidget *aParent) :
+     connect(_ui->transparencySlider, &QSlider::valueChanged, this,
+             &Konsole::ColorSchemeEditor::setTransparencyPercentLabel);
+ 
++    // blur behind window
++    connect(_ui->blurCheckBox, &QCheckBox::toggled, this,
++            &Konsole::ColorSchemeEditor::setBlur);
++
+     // randomized background
+     connect(_ui->randomizedBackgroundCheck, &QCheckBox::toggled, this,
+             &Konsole::ColorSchemeEditor::setRandomizedBackgroundColor);
+@@ -248,6 +252,11 @@ void ColorSchemeEditor::setTransparencyPercentLabel(int percent)
+     _colors->setOpacity(opacity);
+ }
+ 
++void ColorSchemeEditor::setBlur(bool blur)
++{
++    _colors->setBlur(blur);
++}
++
+ void ColorSchemeEditor::setRandomizedBackgroundColor(bool randomize)
+ {
+     _colors->setRandomizedBackgroundColor(randomize);
+@@ -279,6 +288,9 @@ void ColorSchemeEditor::setup(const ColorScheme *scheme, bool isNewScheme)
+     _ui->transparencySlider->setValue(transparencyPercent);
+     setTransparencyPercentLabel(transparencyPercent);
+ 
++    // blur behind window checkbox
++    _ui->blurCheckBox->setChecked(scheme->blur());
++
+     // randomized background color checkbox
+     _ui->randomizedBackgroundCheck->setChecked(scheme->randomizedBackgroundColor());
+ 
+diff --git a/src/ColorSchemeEditor.h b/src/ColorSchemeEditor.h
+index 20582dc..500794f 100644
+--- a/src/ColorSchemeEditor.h
++++ b/src/ColorSchemeEditor.h
+@@ -77,6 +77,7 @@ public Q_SLOTS:
+ 
+ private Q_SLOTS:
+     void setTransparencyPercentLabel(int percent);
++    void setBlur(bool blur);
+     void setRandomizedBackgroundColor(bool randomized);
+     void editColorItem(QTableWidgetItem *item);
+     void wallpaperPathChanged(const QString &path);
+diff --git a/src/ColorSchemeEditor.ui b/src/ColorSchemeEditor.ui
+index 45f9446..440a6b8 100644
+--- a/src/ColorSchemeEditor.ui
++++ b/src/ColorSchemeEditor.ui
+@@ -42,6 +42,13 @@
+     </widget>
+    </item>
+    <item>
++    <widget class="QCheckBox" name="blurCheckBox">
++     <property name="text">
++      <string>Blur background</string>
++     </property>
++    </widget>
++   </item>
++   <item>
+     <layout class="QHBoxLayout">
+      <item>
+       <widget class="QLabel" name="transparencyLabel">
+diff --git a/src/MainWindow.cpp b/src/MainWindow.cpp
+index ce9fa79..e78858d 100644
+--- a/src/MainWindow.cpp
++++ b/src/MainWindow.cpp
+@@ -31,6 +31,7 @@
+ #include <KLocalizedString>
+ #include <KToggleAction>
+ #include <KToggleFullScreenAction>
++#include <KWindowEffects>
+ 
+ #include <QMenu>
+ #include <QMenuBar>
+@@ -98,6 +99,8 @@ MainWindow::MainWindow() :
+             &Konsole::MainWindow::disconnectController);
+     connect(_viewManager, &Konsole::ViewManager::viewPropertiesChanged,
+             bookmarkHandler(), &Konsole::BookmarkHandler::setViews);
++    connect(_viewManager, &Konsole::ViewManager::blurSettingChanged,
++            this, &Konsole::MainWindow::setBlur);
+ 
+     connect(_viewManager, &Konsole::ViewManager::updateWindowIcon, this,
+             &Konsole::MainWindow::updateWindowIcon);
+@@ -240,6 +243,8 @@ void MainWindow::activeViewChanged(SessionController *controller)
+     Q_ASSERT(controller);
+     _pluggedController = controller;
+ 
++    setBlur(ViewManager::profileHasBlurEnabled(SessionManager::instance()->sessionProfile(_pluggedController->session())));
++
+     // listen for title changes from the current session
+     connect(controller, &Konsole::SessionController::titleChanged, this,
+             &Konsole::MainWindow::activeViewTitleChanged);
+@@ -876,6 +881,17 @@ void MainWindow::configureNotifications()
+     KNotifyConfigWidget::configure(this);
+ }
+ 
++void MainWindow::setBlur(bool blur)
++{
++    if (_pluggedController == nullptr) {
++        return;
++    }
++
++    if (!_pluggedController->isKonsolePart()) {
++        KWindowEffects::enableBlurBehind(winId(), blur);
++    }
++}
++
+ void MainWindow::setMenuBarInitialVisibility(bool visible)
+ {
+     _menuBarInitialVisibility = visible;
+diff --git a/src/MainWindow.h b/src/MainWindow.h
+index 6908ccc..a912d56 100644
+--- a/src/MainWindow.h
++++ b/src/MainWindow.h
+@@ -158,6 +158,7 @@ private Q_SLOTS:
+ 
+     void profileListChanged(const QList<QAction *> &sessionActions);
+     void configureNotifications();
++    void setBlur(bool blur);
+ 
+     void updateWindowIcon();
+     void updateWindowCaption();
+diff --git a/src/SessionController.h b/src/SessionController.h
+index 81fef60..638bff1 100644
+--- a/src/SessionController.h
++++ b/src/SessionController.h
+@@ -173,6 +173,9 @@ public:
+         return _allControllers;
+     }
+ 
++    /* Returns true if called within a KPart; false if called within Konsole. */
++    bool isKonsolePart() const;
++
+ Q_SIGNALS:
+     /**
+      * Emitted when the view associated with the controller is focused.
+@@ -309,9 +312,6 @@ private:
+     void setFindNextPrevEnabled(bool enabled);
+     void listenForScreenWindowUpdates();
+ 
+-    /* Returns true if called within a KPart; false if called within Konsole. */
+-    bool isKonsolePart() const;
+-
+ private:
+     void updateSessionIcon();
+ 
+diff --git a/src/ViewManager.cpp b/src/ViewManager.cpp
+index a1a9455..f3d7eb3 100644
+--- a/src/ViewManager.cpp
++++ b/src/ViewManager.cpp
+@@ -860,6 +860,11 @@ const ColorScheme *ViewManager::colorSchemeForProfile(const Profile::Ptr profile
+     return colorScheme;
+ }
+ 
++bool ViewManager::profileHasBlurEnabled(const Profile::Ptr profile)
++{
++    return colorSchemeForProfile(profile)->blur();
++}
++
+ void ViewManager::applyProfileToView(TerminalDisplay *view, const Profile::Ptr profile)
+ {
+     Q_ASSERT(profile);
+@@ -874,6 +879,8 @@ void ViewManager::applyProfileToView(TerminalDisplay *view, const Profile::Ptr p
+     view->setOpacity(colorScheme->opacity());
+     view->setWallpaper(colorScheme->wallpaper());
+ 
++    emit blurSettingChanged(colorScheme->blur());
++
+     // load font
+     view->setAntialias(profile->antiAliasFonts());
+     view->setBoldIntense(profile->boldIntense());
+diff --git a/src/ViewManager.h b/src/ViewManager.h
+index 62d0ee4..2e612d5 100644
+--- a/src/ViewManager.h
++++ b/src/ViewManager.h
+@@ -179,6 +179,11 @@ public:
+         return _sessionMap.values();
+     }
+ 
++    /**
++     * Returns whether the @p profile has the blur setting enabled
++     */
++    static bool profileHasBlurEnabled(const Profile::Ptr profile);
++
+ Q_SIGNALS:
+     /** Emitted when the last view is removed from the view manager */
+     void empty();
+@@ -222,6 +227,8 @@ Q_SIGNALS:
+     void setMenuBarVisibleRequest(bool);
+     void updateWindowIcon();
+ 
++    void blurSettingChanged(bool);
++
+     /** Requests creation of a new view with the default profile. */
+     void newViewRequest();
+     /** Requests creation of a new view, with the selected profile. */
+-- 
+cgit v0.11.2
+


### PR DESCRIPTION
Add option to ColorScheme to blur transparent background

Note that this does not affect KonsolePart; it is up to the app using
it to enable transparency (see src/tests/demo_konsolepart).

Patch by anemeth https://cgit.kde.org/konsole.git/patch/?id=c63525f adapted for kde applications 17.12.
